### PR TITLE
Issue#11 result sessions

### DIFF
--- a/ReactionTimeApp/Controller/Controller.swift
+++ b/ReactionTimeApp/Controller/Controller.swift
@@ -16,12 +16,24 @@ import Foundation
 
     var recentResult: TimeInterval? {
         testModel.recentResult
-    } //We will use a didSet here to send new results to the ResultStore, if the result is nil we will not send it
+    }
 
+    var resultCount: Int {
+        testModel.resultCount
+    }
 
+    var recentSessionResult: Double? {
+        testModel.recentSessionResult
+    }
 
     func pressTimerButton () {
         testModel.pressTimerButton()
+    }
+
+    func saveSessionResult () {
+        if let _ = testModel.recentSessionResult {
+            //store.saveResult(result)
+        }
     }
 
 }

--- a/ReactionTimeApp/Controller/Controller.swift
+++ b/ReactionTimeApp/Controller/Controller.swift
@@ -10,7 +10,7 @@ import Foundation
 @Observable class Controller {
     var testModel: TestLogic = TestLogic()
 
-    var testState: TestState {
+    var testState: timerState {
         testModel.testState
     }
 

--- a/ReactionTimeApp/Model/TestLogic.swift
+++ b/ReactionTimeApp/Model/TestLogic.swift
@@ -9,30 +9,38 @@ import Foundation
 
 struct TestLogic {
     var session: TestSession = TestSession()
-
     var sessionTestTotalCount: Int = 5
     var currentTestCount: Int = 0
-
-
-    var recentResult: TimeInterval? {
-            session.recentReaction
-    }
-
     var recentSessionResult: Double? = nil
 
     var testState: timerState {
         session.testState
     }
-    
+
+    var recentResult: TimeInterval? {
+            session.recentReaction
+    }
+
+    var resultCount: Int {
+        session.resultCount
+    }
+
     mutating func pressTimerButton () {
         if (session.testState == .dormant || session.testState == .falseStart) {
             session.waitRandomTime()
         }
+        else if (session.testState == .endOfSession) {
+            session = TestSession()
+        }
         else if (session.testState == .waitingForUser) {
             session.recordUserReaction()
+            if (resultCount == session.maxResultCount) {
+                recentSessionResult = session.sessionAverageResult
+            }
         }
         else if (session.testState == .waitingRandomTime) {
-            session = TestSession()
+            //recreate session so we can avoid waiting for timer to end
+            session = TestSession(results: session.sessionResults, resultCount: session.resultCount)
             session.testState = .falseStart
         }
     }

--- a/ReactionTimeApp/Model/TestLogic.swift
+++ b/ReactionTimeApp/Model/TestLogic.swift
@@ -8,32 +8,32 @@
 import Foundation
 
 struct TestLogic {
-    var timer: TestTimer = TestTimer()
+    var session: TestSession = TestSession()
 
     var sessionTestTotalCount: Int = 5
     var currentTestCount: Int = 0
 
 
     var recentResult: TimeInterval? {
-            timer.recentReaction
+            session.recentReaction
     }
 
     var recentSessionResult: Double? = nil
 
     var testState: timerState {
-        timer.testState
+        session.testState
     }
     
     mutating func pressTimerButton () {
-        if (timer.testState == .dormant || timer.testState == .falseStart) {
-            timer.waitRandomTime()
+        if (session.testState == .dormant || session.testState == .falseStart) {
+            session.waitRandomTime()
         }
-        else if (timer.testState == .waitingForUser) {
-            timer.recordUserReaction()
+        else if (session.testState == .waitingForUser) {
+            session.recordUserReaction()
         }
-        else if (timer.testState == .waitingRandomTime) {
-            timer = TestTimer()
-            timer.testState = .falseStart
+        else if (session.testState == .waitingRandomTime) {
+            session = TestSession()
+            session.testState = .falseStart
         }
     }
 

--- a/ReactionTimeApp/Model/TestLogic.swift
+++ b/ReactionTimeApp/Model/TestLogic.swift
@@ -10,23 +10,19 @@ import Foundation
 struct TestLogic {
     var timer: TestTimer = TestTimer()
 
+    var sessionTestTotalCount: Int = 5
+    var currentTestCount: Int = 0
+
+
     var recentResult: TimeInterval? {
-        timer.recentReaction
+            timer.recentReaction
     }
 
-    var testState: TestState {
+    var recentSessionResult: Double? = nil
+
+    var testState: timerState {
         timer.testState
     }
-    //will handle the logic of what state the timer is in when the user presses the button
-    //and how to handle that input
-    //if the test is inactive then we want to display to the user to press and start a test, and a tapGesture would start the test
-    //
-    //if the test is waiting then we want to display the button as red and tell the user to wait for green, pressing here will result in testState set to falseStart
-    //
-    //if the test is active then we want to display the button as green, pressing here will result in a successful test and testState will be set to ended and the result displayed,
-    //if the test is falseStart then we want to tell the user they pressed too soon, pressing again will start a new test
-    //
-    //if the test is ended we want to display the result, pressing again will start a new test
     
     mutating func pressTimerButton () {
         if (timer.testState == .dormant || timer.testState == .falseStart) {
@@ -40,5 +36,6 @@ struct TestLogic {
             timer.testState = .falseStart
         }
     }
+
 
 }

--- a/ReactionTimeApp/Model/TestSession.swift
+++ b/ReactionTimeApp/Model/TestSession.swift
@@ -7,13 +7,16 @@
 
 import Foundation
 
-@Observable class TestTimer {
+@Observable class TestSession {
     var testState: timerState = .dormant
     var randomTimeInterval: Double = 0
     var testStartTime: Date = Date.now
     var recentReaction: TimeInterval? = nil
     var minRandomWaitTime: Double
     var maxRandomWaitTime: Double
+    var maxResultCount: Int = 5
+    var sessionResults: [TimeInterval] = []
+    var sessionAverageResult: Double? = nil
 
 
     
@@ -71,4 +74,5 @@ enum timerState {
     case waitingForUser
     case waitingRandomTime
     case falseStart
+    case endOfSession
 }

--- a/ReactionTimeApp/Model/TestSession.swift
+++ b/ReactionTimeApp/Model/TestSession.swift
@@ -15,15 +15,25 @@ import Foundation
     var minRandomWaitTime: Double
     var maxRandomWaitTime: Double
     var maxResultCount: Int = 5
+    var resultCount: Int = 0
     var sessionResults: [TimeInterval] = []
     var sessionAverageResult: Double? = nil
 
 
-    
+    //this init is for creating a new session
     init() {
         self.testState = .dormant
         self.minRandomWaitTime = 0.3
         self.maxRandomWaitTime = 7.0
+    }
+
+    //this init is to be used to recreate a session that had a false start
+    init(results sessionResults: [TimeInterval], resultCount: Int) {
+        self.testState = .dormant
+        self.minRandomWaitTime = 0.3
+        self.maxRandomWaitTime = 7.0
+        self.sessionResults = sessionResults
+        self.resultCount = resultCount
     }
 
 
@@ -53,12 +63,29 @@ import Foundation
         print("recording user reaction")
         if (testState == .waitingForUser) {
             recentReaction = Date().timeIntervalSince(testStartTime)
+            if let result = recentReaction {
+                sessionResults += [result]
+                resultCount += 1
+            }
         }
-        testState = .dormant
+        if (resultCount == maxResultCount) {
+            calculateAverage()
+            testState = .endOfSession
+        } else {
+            testState = .dormant
+        }
     }
 
     func getRecentResult() -> TimeInterval? {
         recentReaction
+    }
+
+    func calculateAverage() {
+        var totalTime: Double = 0
+        for result in sessionResults {
+            totalTime += result
+        }
+        sessionAverageResult = totalTime / Double (maxResultCount)
     }
 
 

--- a/ReactionTimeApp/Model/TestTimer.swift
+++ b/ReactionTimeApp/Model/TestTimer.swift
@@ -8,13 +8,15 @@
 import Foundation
 
 @Observable class TestTimer {
-    var testState: TestState = .dormant
+    var testState: timerState = .dormant
     var randomTimeInterval: Double = 0
     var testStartTime: Date = Date.now
     var recentReaction: TimeInterval? = nil
     var minRandomWaitTime: Double
     var maxRandomWaitTime: Double
 
+
+    
     init() {
         self.testState = .dormant
         self.minRandomWaitTime = 0.3
@@ -52,6 +54,10 @@ import Foundation
         testState = .dormant
     }
 
+    func getRecentResult() -> TimeInterval? {
+        recentReaction
+    }
+
 
 
 
@@ -60,7 +66,7 @@ import Foundation
 
 }
 
-enum TestState {
+enum timerState {
     case dormant
     case waitingForUser
     case waitingRandomTime

--- a/ReactionTimeApp/View/TabViewComponent.swift
+++ b/ReactionTimeApp/View/TabViewComponent.swift
@@ -17,7 +17,7 @@ struct TabViewComponent: View {
                 testView1
             }
             Tab("Test", systemImage: "bolt", value: 1) {
-                
+
             }
             Tab("Graph", systemImage: "chart.bar.xaxis", value: 2) {
 

--- a/ReactionTimeApp/View/TestViewComponents/TimerViewTemp.swift
+++ b/ReactionTimeApp/View/TestViewComponents/TimerViewTemp.swift
@@ -1,0 +1,31 @@
+//
+//  TimerViewTemp.swift
+//  ReactionTimeApp
+//
+//  Created by Toby Weir on 02/07/2025.
+//
+
+import SwiftUI
+
+struct TimerViewTemp: View {
+    @State var model: Controller = Controller()
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Text("Recent Reaction: \(String(describing: model.recentResult))")
+        Text("Test State -> \(model.testState)")
+        testButton
+    }
+
+    var testButton: some View {
+        Button {
+            model.pressTimerButton()
+        } label: {
+            Text("Press here for timer")
+        }
+
+    }
+}
+
+#Preview {
+    TimerViewTemp()
+}

--- a/ReactionTimeApp/View/TestViewComponents/TimerViewTemp.swift
+++ b/ReactionTimeApp/View/TestViewComponents/TimerViewTemp.swift
@@ -11,7 +11,9 @@ struct TimerViewTemp: View {
     @State var model: Controller = Controller()
     var body: some View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Text("Result Count: \(model.resultCount)")
         Text("Recent Reaction: \(String(describing: model.recentResult))")
+        Text("Recent Average: \(String(describing: model.recentSessionResult))")
         Text("Test State -> \(model.testState)")
         testButton
     }


### PR DESCRIPTION
TestTimer has been redefined as TestSession and expects more than 1 result and to create an average of these Results, TestLogic also expects this and collects the average as well as recreating TestSession in the case of a falseStart or creating a new session is complete. Integrating these components with the UI should be fairly simple as all possible states are defined by the TestState enum and are published by TestSession.